### PR TITLE
Introduce IPv6 VPC Support

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.22.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:RxPzK6VFHz6qZMZUVhE03j9Cf5CvnLr14egtq5yxD1E=",
+    "zh:299efb8ba733b7742f0ef1c5c5467819e0c7bf46264f5f36ba6b6674304a5244",
+    "zh:4db198a41d248491204d4ca644662c32f748177d5cbe01f3c7adbb957d4d77f0",
+    "zh:62ebc2b05b25eafecb1a75f19d6fc5551faf521ada9df9e5682440d927f642e1",
+    "zh:636b590840095b4f817c176034cf649f543c0ce514dc051d6d0994f0a05c53ef",
+    "zh:8594bd8d442288873eee56c0b4535cbdf02cacfcf8f6ddcf8cd5f45bb1d3bc80",
+    "zh:8e18a370949799f20ba967eec07a84aaedf95b3ee5006fe5af6eae13fbf39dc3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aa968514231e404fb53311d8eae2e8b6bde1fdad1f4dd5a592ab93d9cbf11af4",
+    "zh:af8e5c48bf36d4fff1a6fca760d5b85f14d657cbdf95e9cd5e898c68104bad31",
+    "zh:d8a75ba36bf8b6f2e49be5682f48eccb6c667a4484afd676ae347213ae208622",
+    "zh:dd7c419674a47e587dabe98b150a8f1f7e31c248c68e8bf5e9ca0a400b5e2c4e",
+    "zh:fdeb6314a2ce97489bbbece59511f78306955e8a23b02cbd1485bd04185a3673",
+  ]
+}

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,21 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.22.0"
+  version     = "4.59.0"
   constraints = "~> 4.0"
   hashes = [
-    "h1:RxPzK6VFHz6qZMZUVhE03j9Cf5CvnLr14egtq5yxD1E=",
-    "zh:299efb8ba733b7742f0ef1c5c5467819e0c7bf46264f5f36ba6b6674304a5244",
-    "zh:4db198a41d248491204d4ca644662c32f748177d5cbe01f3c7adbb957d4d77f0",
-    "zh:62ebc2b05b25eafecb1a75f19d6fc5551faf521ada9df9e5682440d927f642e1",
-    "zh:636b590840095b4f817c176034cf649f543c0ce514dc051d6d0994f0a05c53ef",
-    "zh:8594bd8d442288873eee56c0b4535cbdf02cacfcf8f6ddcf8cd5f45bb1d3bc80",
-    "zh:8e18a370949799f20ba967eec07a84aaedf95b3ee5006fe5af6eae13fbf39dc3",
+    "h1:fuIdjl9f2JEH0TLoq5kc9NIPbJAAV7YBbZ8fvNp5XSg=",
+    "zh:0341a460210463a0bebd5c12ce13dc49bd8cae2399b215418c5efa607fed84e4",
+    "zh:0544e9bbdd31d3551e7273bed7326d26a28653fd9c26b5cd06ac8ed76f188798",
+    "zh:3d13acd0363f0a48d2725cae9d224481df38dddb90ef4a66eb82303f0aa45a99",
+    "zh:416f5b92d41dce1d7ee1a1acb06ba8b0f10679eecee2fcc134853adbb09d9757",
+    "zh:80c9c3b901151cd697caa58bfa196816d4622e4ce11aa789e36efc460695313b",
+    "zh:8fc3659ebdae1ac9de899f57e5a3a50274a2e96c46aa2cf74be51ffdac56300a",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:aa968514231e404fb53311d8eae2e8b6bde1fdad1f4dd5a592ab93d9cbf11af4",
-    "zh:af8e5c48bf36d4fff1a6fca760d5b85f14d657cbdf95e9cd5e898c68104bad31",
-    "zh:d8a75ba36bf8b6f2e49be5682f48eccb6c667a4484afd676ae347213ae208622",
-    "zh:dd7c419674a47e587dabe98b150a8f1f7e31c248c68e8bf5e9ca0a400b5e2c4e",
-    "zh:fdeb6314a2ce97489bbbece59511f78306955e8a23b02cbd1485bd04185a3673",
+    "zh:a235b44ad074446a6138b3fb454dd0d234aacf7a1efea89d1eafac7284689d19",
+    "zh:a36a7f1cd7f9f6c45127d916a65b5441cc0430393535a5a3de4b646405c50c41",
+    "zh:c161c38727902271efa19020b95b69ebe0282989d575f31dff603a1d551bafd2",
+    "zh:d1562223347c49cbe3ff6e7295e25816a35dfef862d28cd8a7870e7be6ec8093",
+    "zh:e7a1d08bfe91d3789755ee587fc816907c3bea203342c717144c7459111ce20c",
+    "zh:e89d5a668c391669ed323d493c5ea131fe8833d562a6fe31f525bdcbe959056e",
+    "zh:f268ccd3e1a32ba7fd59bbf0c8d85611201c0c87462a2a5cddd02babde7b5fe8",
+    "zh:fe8c2eae8c367d2cb7cade250a8d5f6c411ac4a8214c46df0a1fd90d9eaf7152",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,37 +1,74 @@
 # terraform-aws-vpc
 Terraform Module for AWS VPC and subnets creation.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.22.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_subnet_group.db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_egress_only_internet_gateway.egress_only_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/egress_only_internet_gateway) | resource |
+| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_internet_gateway.internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.nat_gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_route.private_egress_gateway_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.public_internet_gateway_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route_table.private_nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.private_nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| availability\_zones | A list of availability zones in the region | `list(string)` | n/a | yes |
-| aws\_region | AWS Region for develop infra | `string` | `"us-east-1"` | no |
-| cidr\_block | CIDR for dev VPC | `string` | n/a | yes |
-| database\_subnets | A list all the database subnets in the VPC | `list(string)` | n/a | yes |
-| enable\_dns\_hostnames | Enable/Disable DNS hostnames in the VPC | `bool` | `true` | no |
-| enable\_dns\_support | Enable/Disable DNS support in the VPC | `bool` | `true` | no |
-| enable\_nat\_gateway | Enable/Disable nat gateway in public subnets to enable internet access in private subnet | `bool` | `true` | no |
-| env | Deployment Environment | `string` | n/a | yes |
-| instance\_tenancy | A tenancy option for instances in the VPC | `string` | `"default"` | no |
-| private\_subnets | A list all the private subnets in the VPC | `list(string)` | n/a | yes |
-| public\_subnets | A list all the public subnets in the VPC | `list(string)` | n/a | yes |
-| service\_name | Name of the service | `string` | n/a | yes |
-| tags | Tags for VPC | `map(string)` | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of availability zones in the region | `list(string)` | n/a | yes |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS Region for develop infra | `string` | `"default"` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region for develop infra | `string` | `"us-east-1"` | no |
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | CIDR for dev VPC | `string` | n/a | yes |
+| <a name="input_database_ipv4_subnets"></a> [database\_ipv4\_subnets](#input\_database\_ipv4\_subnets) | A list all the database IPv4 subnets in the VPC | `list(string)` | n/a | yes |
+| <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | Enable/Disable DNS hostnames in the VPC | `bool` | `true` | no |
+| <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Enable/Disable DNS support in the VPC | `bool` | `true` | no |
+| <a name="input_enable_ipv6_egw"></a> [enable\_ipv6\_egw](#input\_enable\_ipv6\_egw) | Enable/Disable Egress-only Gateway to enable internet access in private IPv6 subnet | `bool` | `true` | no |
+| <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable/Disable nat gateway in public subnets to enable internet access in private subnet | `bool` | `true` | no |
+| <a name="input_enable_vpc_ipv6"></a> [enable\_vpc\_ipv6](#input\_enable\_vpc\_ipv6) | Enables IPv6 Support in the VPC | `bool` | `false` | no |
+| <a name="input_env"></a> [env](#input\_env) | Deployment Environment | `string` | n/a | yes |
+| <a name="input_instance_tenancy"></a> [instance\_tenancy](#input\_instance\_tenancy) | A tenancy option for instances in the VPC | `string` | `"default"` | no |
+| <a name="input_private_ipv4_subnets"></a> [private\_ipv4\_subnets](#input\_private\_ipv4\_subnets) | A list all the private IPv4 subnets in the VPC | `list(string)` | n/a | yes |
+| <a name="input_public_ipv4_subnets"></a> [public\_ipv4\_subnets](#input\_public\_ipv4\_subnets) | A list all the public IPv4 subnets in the VPC | `list(string)` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags for VPC | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| aws\_db\_subnet\_group\_name | VPC database subnet group name |
-| cidr\_block | VPC CIDR block |
-| database\_subnets\_ids | VPC database subnet ids |
-| id | VPC ID |
-| private\_subnets\_ids | VPC private subnet ids |
-| public\_subnet\_ids | VPC public subnet ids |
-
+| <a name="output_aws_db_subnet_group_name"></a> [aws\_db\_subnet\_group\_name](#output\_aws\_db\_subnet\_group\_name) | VPC database subnet group name |
+| <a name="output_cidr_block"></a> [cidr\_block](#output\_cidr\_block) | VPC CIDR block |
+| <a name="output_database_subnets_ids"></a> [database\_subnets\_ids](#output\_database\_subnets\_ids) | VPC database subnet ids |
+| <a name="output_id"></a> [id](#output\_id) | VPC ID |
+| <a name="output_ipv6_cidr_block"></a> [ipv6\_cidr\_block](#output\_ipv6\_cidr\_block) | VPC IPv6 CIDR block |
+| <a name="output_private_subnets_ids"></a> [private\_subnets\_ids](#output\_private\_subnets\_ids) | VPC private subnet ids |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | VPC public subnet ids |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform Module for AWS VPC and subnets creation.
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 4.0 |
 
 ## Inputs
 

--- a/examples/basic/ci.auto.tfvars
+++ b/examples/basic/ci.auto.tfvars
@@ -8,7 +8,7 @@ vpc_serice_name = "scalereal"
 
 vpc_cidr_block = "10.0.0.0/16"
 
-vpc_public_subnets= ["10.0.0.0/24", "10.0.1.0/24"]
+vpc_public_subnets = ["10.0.0.0/24", "10.0.1.0/24"]
 
 vpc_private_subnets = ["10.0.2.0/24", "10.0.3.0/24"]
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,12 +4,12 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "../../"
-  env = var.vpc_env
-  cidr_block = var.vpc_cidr_block
-  service_name = var.vpc_serice_name
+  source             = "../../"
+  env                = var.vpc_env
+  cidr_block         = var.vpc_cidr_block
+  service_name       = var.vpc_serice_name
   availability_zones = var.vpc_availability_zones
-  database_subnets = var.vpc_database_subnets
-  private_subnets = var.vpc_private_subnets
-  public_subnets = var.vpc_public_subnets
+  database_subnets   = var.vpc_database_subnets
+  private_subnets    = var.vpc_private_subnets
+  public_subnets     = var.vpc_public_subnets
 }

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_route" "private_nat_gateway" {
 }
 
 resource "aws_route" "private_egress_gateway_ipv6" {
-  count                       = var.enable_vpc_ipv6 ? 1 : 0
+  count                       = var.enable_ipv6_egw && var.enable_vpc_ipv6 ? 1 : 0
   route_table_id              = aws_route_table.private_nat[count.index].id
   destination_ipv6_cidr_block = "::/0"
   egress_only_gateway_id      = aws_egress_only_internet_gateway.egress_only_gateway.id

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_vpc" "vpc" {
   instance_tenancy     = var.instance_tenancy
   enable_dns_support   = var.enable_dns_support
   enable_dns_hostnames = var.enable_dns_hostnames
-
+  assign_generated_ipv6_cidr_block = var.enable_vpc_ipv6
   tags = merge(var.tags,  {"Name" = format("%s-%s-vpc", var.service_name, var.env)})
 }
 

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,19 @@ resource "aws_route_table" "public" {
   depends_on = [aws_vpc.vpc, aws_internet_gateway.internet_gateway]
 }
 
+resource "aws_route" "public_internet_gateway" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.internet_gateway.id
+}
+
+resource "aws_route" "public_internet_gateway_ipv6" {
+  count                       = var.enable_vpc_ipv6 ? 1 : 0
+  route_table_id              = aws_route_table.public.id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.internet_gateway.id
+}
+
 resource "aws_route_table_association" "public" {
   count          = length(var.public_ipv4_subnets)
   route_table_id = aws_route_table.public.id

--- a/main.tf
+++ b/main.tf
@@ -54,17 +54,6 @@ resource "aws_egress_only_internet_gateway" "egress_only_gateway" {
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.internet_gateway.id
-  }
-
-  route {
-    ipv6_cidr_block        = "::/0"
-    egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
-  }
-
   tags       = merge(var.tags, {"Name" = format("%s-%s-public-route-table", var.service_name, var.env)})
   depends_on = [aws_vpc.vpc, aws_internet_gateway.internet_gateway]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 resource "aws_vpc" "vpc" {
-  cidr_block           = var.cidr_block
-  instance_tenancy     = var.instance_tenancy
-  enable_dns_support   = var.enable_dns_support
-  enable_dns_hostnames = var.enable_dns_hostnames
+  cidr_block                       = var.cidr_block
+  instance_tenancy                 = var.instance_tenancy
+  enable_dns_support               = var.enable_dns_support
+  enable_dns_hostnames             = var.enable_dns_hostnames
   assign_generated_ipv6_cidr_block = var.enable_vpc_ipv6
-  tags = merge(var.tags,  {"Name" = format("%s-%s-vpc", var.service_name, var.env)})
+  tags                             = merge(var.tags, { "Name" = format("%s-%s-vpc", var.service_name, var.env) })
 }
 
 resource "aws_subnet" "public" {
@@ -14,7 +14,7 @@ resource "aws_subnet" "public" {
   ipv6_cidr_block         = var.enable_vpc_ipv6 ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index) : null
   availability_zone       = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
-  tags                    = merge(var.tags, { "type" = "public" }, {"Name" = format("%s-%s-public-subnet-%s", var.service_name, var.env, element(var.availability_zones, count.index))})
+  tags                    = merge(var.tags, { "type" = "public" }, { "Name" = format("%s-%s-public-subnet-%s", var.service_name, var.env, element(var.availability_zones, count.index)) })
   depends_on              = [aws_vpc.vpc]
 }
 
@@ -22,10 +22,10 @@ resource "aws_subnet" "private" {
   count                   = length(var.private_ipv4_subnets)
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = var.private_ipv4_subnets[count.index]
-  ipv6_cidr_block         = var.enable_vpc_ipv6 ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index+30) : null
+  ipv6_cidr_block         = var.enable_vpc_ipv6 ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index + 30) : null
   availability_zone       = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
-  tags                    = merge(var.tags, { "type" = "private" }, {"Name" = format("%s-%s-private-subnent-%s", var.service_name, var.env, element(var.availability_zones, count.index))})
+  tags                    = merge(var.tags, { "type" = "private" }, { "Name" = format("%s-%s-private-subnent-%s", var.service_name, var.env, element(var.availability_zones, count.index)) })
   depends_on              = [aws_vpc.vpc]
 }
 
@@ -33,28 +33,28 @@ resource "aws_subnet" "database" {
   count                   = length(var.database_ipv4_subnets)
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = var.database_ipv4_subnets[count.index]
-  ipv6_cidr_block         = var.enable_vpc_ipv6 ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index+60) : null
+  ipv6_cidr_block         = var.enable_vpc_ipv6 ? cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, count.index + 60) : null
   availability_zone       = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
-  tags                    = merge(var.tags, { "type" = "database" }, {"Name" = format("%s-%s-database-subnent-%s", var.service_name, var.env, element(var.availability_zones, count.index))})
+  tags                    = merge(var.tags, { "type" = "database" }, { "Name" = format("%s-%s-database-subnent-%s", var.service_name, var.env, element(var.availability_zones, count.index)) })
   depends_on              = [aws_vpc.vpc]
 }
 
 resource "aws_internet_gateway" "igw" {
   vpc_id     = aws_vpc.vpc.id
-  tags       = merge(var.tags, {"Name" = format("%s-%s-internet-gateway", var.service_name, var.env)})
+  tags       = merge(var.tags, { "Name" = format("%s-%s-internet-gateway", var.service_name, var.env) })
   depends_on = [aws_vpc.vpc]
 }
 
 resource "aws_egress_only_internet_gateway" "egw" {
-  vpc_id      = aws_vpc.vpc.id
-  tags        = merge(var.tags, {"Name" = format("%s-%s-egress-gateway", var.service_name, var.env)})
-  depends_on  = [aws_vpc.vpc]
+  vpc_id     = aws_vpc.vpc.id
+  tags       = merge(var.tags, { "Name" = format("%s-%s-egress-gateway", var.service_name, var.env) })
+  depends_on = [aws_vpc.vpc]
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.vpc.id
-  tags       = merge(var.tags, {"Name" = format("%s-%s-public-route-table", var.service_name, var.env)})
+  vpc_id     = aws_vpc.vpc.id
+  tags       = merge(var.tags, { "Name" = format("%s-%s-public-route-table", var.service_name, var.env) })
   depends_on = [aws_vpc.vpc, aws_internet_gateway.igw]
 }
 
@@ -99,7 +99,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_eip" "nat" {
   count      = var.enable_nat_gateway ? 1 : 0
   vpc        = true
-  tags       = merge(var.tags, {"Name" = format("%s-%s-nat-eip", var.service_name, var.env)})
+  tags       = merge(var.tags, { "Name" = format("%s-%s-nat-eip", var.service_name, var.env) })
   depends_on = [aws_vpc.vpc, aws_route_table.public, aws_internet_gateway.igw, aws_route_table_association.public]
 }
 
@@ -107,14 +107,14 @@ resource "aws_nat_gateway" "nat_gw" {
   count         = var.enable_nat_gateway ? 1 : 0
   allocation_id = aws_eip.nat[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
-  tags          = merge(var.tags, {"Name" = format("%s-%s-nat-gateway", var.service_name, var.env)})
+  tags          = merge(var.tags, { "Name" = format("%s-%s-nat-gateway", var.service_name, var.env) })
   depends_on    = [aws_vpc.vpc, aws_eip.nat]
 }
 
 resource "aws_route_table" "private_nat" {
-  count  = var.enable_nat_gateway ? 1 : 0
-  vpc_id = aws_vpc.vpc.id
-  tags = merge(var.tags, {"Name" = format("%s-%s-private-nat-route-table", var.service_name, var.env)})
+  count      = var.enable_nat_gateway ? 1 : 0
+  vpc_id     = aws_vpc.vpc.id
+  tags       = merge(var.tags, { "Name" = format("%s-%s-private-nat-route-table", var.service_name, var.env) })
   depends_on = [aws_vpc.vpc, aws_subnet.private, aws_nat_gateway.nat_gw]
 }
 
@@ -129,5 +129,5 @@ resource "aws_db_subnet_group" "db_subnet_group" {
   count      = length(var.database_ipv4_subnets) > 0 ? 1 : 0
   name       = "${var.service_name}-${var.env}-db-subnet-group"
   subnet_ids = aws_subnet.database.*.id
-  tags       = merge(var.tags, {"Name" = format("%s-%s-db-subnet-group", var.service_name, var.env)})
+  tags       = merge(var.tags, { "Name" = format("%s-%s-db-subnet-group", var.service_name, var.env) })
 }

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,12 @@ resource "aws_internet_gateway" "internet_gateway" {
   depends_on = [aws_vpc.vpc]
 }
 
+resource "aws_egress_only_internet_gateway" "egress_only_gateway" {
+  vpc_id      = aws_vpc.vpc.id
+  tags        = merge(var.tags, {"Name" = format("%s-%s-egress-gateway", var.service_name, var.env)})
+  depends_on  = [aws_vpc.vpc]
+}
+
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.vpc.id
 

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ resource "aws_route" "public_internet_gateway" {
   route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.internet_gateway.id
+  depends_on             = [aws_vpc.vpc, aws_internet_gateway.internet_gateway, aws_route_table.public]
 }
 
 resource "aws_route" "public_internet_gateway_ipv6" {
@@ -69,6 +70,7 @@ resource "aws_route" "public_internet_gateway_ipv6" {
   route_table_id              = aws_route_table.public.id
   destination_ipv6_cidr_block = "::/0"
   gateway_id                  = aws_internet_gateway.internet_gateway.id
+  depends_on                  = [aws_vpc.vpc, aws_internet_gateway.internet_gateway, aws_route_table.public]
 }
 
 resource "aws_route" "private_nat_gateway" {
@@ -76,6 +78,7 @@ resource "aws_route" "private_nat_gateway" {
   route_table_id         = aws_route_table.private_nat[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.nat_gw[count.index].id
+  depends_on             = [aws_vpc.vpc, aws_route_table.public, aws_nat_gateway.nat_gw]
 }
 
 resource "aws_route" "private_egress_gateway_ipv6" {
@@ -83,6 +86,7 @@ resource "aws_route" "private_egress_gateway_ipv6" {
   route_table_id              = aws_route_table.private_nat[count.index].id
   destination_ipv6_cidr_block = "::/0"
   egress_only_gateway_id      = aws_egress_only_internet_gateway.egress_only_gateway.id
+  depends_on                  = [aws_vpc.vpc, aws_route_table.public, aws_egress_only_internet_gateway.egress_only_gateway]
 }
 
 resource "aws_route_table_association" "public" {

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,20 @@ resource "aws_route" "public_internet_gateway_ipv6" {
   gateway_id                  = aws_internet_gateway.internet_gateway.id
 }
 
+resource "aws_route" "private_nat_gateway" {
+  count                  = var.enable_nat_gateway ? 1 : 0
+  route_table_id         = aws_route_table.private_nat[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat_gw[count.index].id
+}
+
+resource "aws_route" "private_egress_gateway_ipv6" {
+  count                       = var.enable_vpc_ipv6 ? 1 : 0
+  route_table_id              = aws_route_table.private_nat[count.index].id
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.egress_only_gateway.id
+}
+
 resource "aws_route_table_association" "public" {
   count          = length(var.public_ipv4_subnets)
   route_table_id = aws_route_table.public.id

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "public" {
   count                   = length(var.public_subnets)
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.public_subnets[count.index]
+  cidr_block              = var.public_ipv4_subnets[count.index]
   availability_zone       = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
   tags                    = merge(var.tags, { "type" = "public" }, {"Name" = format("%s-%s-public-subnet-%s", var.service_name, var.env, element(var.availability_zones, count.index))})
@@ -20,7 +20,7 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "private" {
   count                   = length(var.private_subnets)
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.private_subnets[count.index]
+  cidr_block              = var.private_ipv4_subnets[count.index]
   availability_zone       = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
   tags                    = merge(var.tags, { "type" = "private" }, {"Name" = format("%s-%s-private-subnent-%s", var.service_name, var.env, element(var.availability_zones, count.index))})
@@ -30,7 +30,7 @@ resource "aws_subnet" "private" {
 resource "aws_subnet" "database" {
   count                   = length(var.database_subnets)
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.database_subnets[count.index]
+  cidr_block              = var.database_ipv4_subnets[count.index]
   availability_zone       = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
   tags                    = merge(var.tags, { "type" = "database" }, {"Name" = format("%s-%s-database-subnent-%s", var.service_name, var.env, element(var.availability_zones, count.index))})

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_egress_only_internet_gateway" "egw" {
+  count      = var.enable_ipv6_egw && var.enable_vpc_ipv6 ? 1 : 0
   vpc_id     = aws_vpc.vpc.id
   tags       = merge(var.tags, { "Name" = format("%s-%s-egress-gateway", var.service_name, var.env) })
   depends_on = [aws_vpc.vpc]
@@ -66,7 +67,6 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_route" "public_internet_gateway_ipv6" {
-  count                       = var.enable_vpc_ipv6 ? 1 : 0
   route_table_id              = aws_route_table.public.id
   destination_ipv6_cidr_block = "::/0"
   gateway_id                  = aws_internet_gateway.igw.id
@@ -85,7 +85,7 @@ resource "aws_route" "private_egress_gateway_ipv6" {
   count                       = var.enable_ipv6_egw && var.enable_vpc_ipv6 ? 1 : 0
   route_table_id              = aws_route_table.private_nat[count.index].id
   destination_ipv6_cidr_block = "::/0"
-  egress_only_gateway_id      = aws_egress_only_internet_gateway.egw.id
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.egw[count.index].id
   depends_on                  = [aws_vpc.vpc, aws_route_table.public, aws_egress_only_internet_gateway.egw]
 }
 

--- a/out.tf
+++ b/out.tf
@@ -24,6 +24,6 @@ output "database_subnets_ids" {
 }
 
 output "aws_db_subnet_group_name" {
-  value = length(var.database_subnets) > 0  ? aws_db_subnet_group.db_subnet_group[0].name : null
+  value = length(var.database_ipv4_subnets) > 0  ? aws_db_subnet_group.db_subnet_group[0].name : null
   description = "VPC database subnet group name"
 }

--- a/out.tf
+++ b/out.tf
@@ -8,6 +8,11 @@ output "cidr_block" {
   description = "VPC CIDR block"
 }
 
+output "ipv6_cidr_block" {
+  value = var.enable_vpc_ipv6 ? aws_vpc.vpc.ipv6_cidr_block : null
+  description = "VPC IPv6 CIDR block"
+}
+
 output "public_subnet_ids" {
   value = aws_subnet.public.*.id
   description = "VPC public subnet ids"

--- a/out.tf
+++ b/out.tf
@@ -1,34 +1,34 @@
 output "id" {
-  value = aws_vpc.vpc.id
+  value       = aws_vpc.vpc.id
   description = "VPC ID"
 }
 
 output "cidr_block" {
-  value = aws_vpc.vpc.cidr_block
+  value       = aws_vpc.vpc.cidr_block
   description = "VPC CIDR block"
 }
 
 output "ipv6_cidr_block" {
-  value = var.enable_vpc_ipv6 ? aws_vpc.vpc.ipv6_cidr_block : null
+  value       = var.enable_vpc_ipv6 ? aws_vpc.vpc.ipv6_cidr_block : null
   description = "VPC IPv6 CIDR block"
 }
 
 output "public_subnet_ids" {
-  value = aws_subnet.public.*.id
+  value       = aws_subnet.public.*.id
   description = "VPC public subnet ids"
 }
 
 output "private_subnets_ids" {
-  value = aws_subnet.private.*.id
+  value       = aws_subnet.private.*.id
   description = "VPC private subnet ids"
 }
 
 output "database_subnets_ids" {
-  value = aws_subnet.database.*.id
+  value       = aws_subnet.database.*.id
   description = "VPC database subnet ids"
 }
 
 output "aws_db_subnet_group_name" {
-  value = length(var.database_ipv4_subnets) > 0  ? aws_db_subnet_group.db_subnet_group[0].name : null
+  value       = length(var.database_ipv4_subnets) > 0 ? aws_db_subnet_group.db_subnet_group[0].name : null
   description = "VPC database subnet group name"
 }

--- a/out.tf
+++ b/out.tf
@@ -18,12 +18,12 @@ output "public_subnet_ids" {
   description = "VPC public subnet ids"
 }
 
-output "private_subnets_ids" {
+output "private_subnet_ids" {
   value       = aws_subnet.private.*.id
   description = "VPC private subnet ids"
 }
 
-output "database_subnets_ids" {
+output "database_subnet_ids" {
   value       = aws_subnet.database.*.id
   description = "VPC database subnet ids"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  profile = var.aws_profile
+  region  = var.aws_region
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  profile = var.aws_profile
-  region  = var.aws_region
-}

--- a/vars.tf
+++ b/vars.tf
@@ -48,16 +48,19 @@ variable "database_ipv4_subnets" {
 variable "public_ipv6_subnets" {
   type        = list(string)
   description = "A list all the public subnets in the VPC"
+  default     = null
 }
 
 variable "private_ipv6_subnets" {
   type        = list(string)
   description = "A list all the private subnets in the VPC"
+  default     = null
 }
 
 variable "database_ipv6_subnets" {
   type        = list(string)
   description = "A list all the database subnets in the VPC"
+  default     = null
 }
 
 variable "tags" {

--- a/vars.tf
+++ b/vars.tf
@@ -14,6 +14,12 @@ variable "aws_region" {
   description = "AWS Region for develop infra"
 }
 
+variable "aws_profile" {
+  type        = string
+  default     = "default"
+  description = "AWS Region for develop infra"
+}
+
 variable "cidr_block" {
   type        = string
   description = "CIDR for dev VPC"

--- a/vars.tf
+++ b/vars.tf
@@ -30,17 +30,32 @@ variable "availability_zones" {
   type        = list(string)
 }
 
-variable "public_subnets" {
+variable "public_ipv4_subnets" {
   type        = list(string)
   description = "A list all the public subnets in the VPC"
 }
 
-variable "private_subnets" {
+variable "private_ipv4_subnets" {
   type        = list(string)
   description = "A list all the private subnets in the VPC"
 }
 
-variable "database_subnets" {
+variable "database_ipv4_subnets" {
+  type        = list(string)
+  description = "A list all the database subnets in the VPC"
+}
+
+variable "public_ipv6_subnets" {
+  type        = list(string)
+  description = "A list all the public subnets in the VPC"
+}
+
+variable "private_ipv6_subnets" {
+  type        = list(string)
+  description = "A list all the private subnets in the VPC"
+}
+
+variable "database_ipv6_subnets" {
   type        = list(string)
   description = "A list all the database subnets in the VPC"
 }
@@ -73,4 +88,10 @@ variable "enable_nat_gateway" {
   type        = bool
   default     = true
   description = "Enable/Disable nat gateway in public subnets to enable internet access in private subnet"
+}
+
+variable "enable_vpc_ipv6" {
+  type        = bool
+  default     = false
+  description = "Enables IPv6 Support in the VPC"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -32,17 +32,17 @@ variable "availability_zones" {
 
 variable "public_ipv4_subnets" {
   type        = list(string)
-  description = "A list all the public subnets in the VPC"
+  description = "A list all the public IPv4 subnets in the VPC"
 }
 
 variable "private_ipv4_subnets" {
   type        = list(string)
-  description = "A list all the private subnets in the VPC"
+  description = "A list all the private IPv4 subnets in the VPC"
 }
 
 variable "database_ipv4_subnets" {
   type        = list(string)
-  description = "A list all the database subnets in the VPC"
+  description = "A list all the database IPv4 subnets in the VPC"
 }
 
 variable "tags" {

--- a/vars.tf
+++ b/vars.tf
@@ -45,24 +45,6 @@ variable "database_ipv4_subnets" {
   description = "A list all the database subnets in the VPC"
 }
 
-variable "public_ipv6_subnets" {
-  type        = list(string)
-  description = "A list all the public subnets in the VPC"
-  default     = null
-}
-
-variable "private_ipv6_subnets" {
-  type        = list(string)
-  description = "A list all the private subnets in the VPC"
-  default     = null
-}
-
-variable "database_ipv6_subnets" {
-  type        = list(string)
-  description = "A list all the database subnets in the VPC"
-  default     = null
-}
-
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/vars.tf
+++ b/vars.tf
@@ -93,6 +93,12 @@ variable "enable_nat_gateway" {
   description = "Enable/Disable nat gateway in public subnets to enable internet access in private subnet"
 }
 
+variable "enable_ipv6_egw" {
+  type        = bool
+  default     = true
+  description = "Enable/Disable Egress-only Gateway to enable internet access in private IPv6 subnet"
+}
+
 variable "enable_vpc_ipv6" {
   type        = bool
   default     = false

--- a/vars.tf
+++ b/vars.tf
@@ -8,18 +8,6 @@ variable "env" {
   description = "Deployment Environment"
 }
 
-variable "aws_region" {
-  type        = string
-  default     = "us-east-1"
-  description = "AWS Region for develop infra"
-}
-
-variable "aws_profile" {
-  type        = string
-  default     = "default"
-  description = "AWS Region for develop infra"
-}
-
 variable "cidr_block" {
   type        = string
   description = "CIDR for dev VPC"

--- a/vars.tf
+++ b/vars.tf
@@ -25,6 +25,7 @@ variable "public_ipv4_subnets" {
 
 variable "private_ipv4_subnets" {
   type        = list(string)
+  default     = []
   description = "A list all the private IPv4 subnets in the VPC"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 01.2"
 
   required_providers {
-    aws = "~> 2.0"
+    aws = "~> 4.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 01.2"
+  required_version = "~> 1.2"
 
   required_providers {
     aws = "~> 4.0"

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 1.4"
+  required_version = "~> 1.5"
 
   required_providers {
-    aws = "~> 4.0"
+    aws = "~> 5.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.2"
+  required_version = "~> 1.4"
 
   required_providers {
     aws = "~> 4.0"


### PR DESCRIPTION
I have tested VPC creation fully with this new patchset, both with and without IPv6 enabled.

Breaking changes:

`public_subnets` is now `public_ipv4_subnets`
`private_subnets` is now `private_ipv4_subnets`
`database_subnets` is now `database_ipv4_subnets`

Newly introduced variables:

`enable_vpc_ipv6` : boolean, set to false by default

Newly introduced outputs:

`ipv6_cidr_block` : Auto assigned CIDR block by amazon